### PR TITLE
Add optional PlayFab orderBy sorting for marketplace list endpoints

### DIFF
--- a/src/controllers/marketplace/tagController.js
+++ b/src/controllers/marketplace/tagController.js
@@ -21,7 +21,7 @@ const cacheKey = require("../../utils/cacheKey");
 exports.getByTag = withETag(withPagination(async (req) => {
     const key = cacheKey(req);
     return dataCache.getOrSetAsync(key, async () => {
-        const items = await service.fetchByTag(req.params.alias, req.params.tag);
+        const items = await service.fetchByTag(req.params.alias, req.params.tag, req.query);
         return items;
     });
 }));

--- a/src/utils/playfab.js
+++ b/src/utils/playfab.js
@@ -227,7 +227,7 @@ function transformItem(item) {
     };
 }
 
-async function fetchAllMarketplaceItemsEfficiently(titleId, filter, os, batchSize = 300, concurrency = 5, maxBatches = Number(process.env.MAX_FETCH_BATCHES || 20)) {
+async function fetchAllMarketplaceItemsEfficiently(titleId, filter, os, batchSize = 300, concurrency = 5, maxBatches = Number(process.env.MAX_FETCH_BATCHES || 20), orderBy = "startDate desc") {
     const all = [];
 
     let nextBatchIndex = 0;
@@ -240,7 +240,7 @@ async function fetchAllMarketplaceItemsEfficiently(titleId, filter, os, batchSiz
             if (batchIndex >= stopAtBatch || batchIndex >= maxBatches) break;
 
             const payload = buildSearchPayload({
-                filter, search: "", top: batchSize, skip: batchIndex * batchSize, orderBy: "startDate desc"
+                filter, search: "", top: batchSize, skip: batchIndex * batchSize, orderBy
             });
             const data = await sendPlayFabRequest(titleId, "Catalog/Search", payload, "X-EntityToken", 3, os);
             const items = data.Items || [];


### PR DESCRIPTION
### Motivation
- Enable clients to provide an `orderBy` URL query for list-style marketplace endpoints so items can be sorted by PlayFab fields (`creationDate`, `lastModifiedDate`, `startDate`, `rating/totalcount`) using the official PlayFab `Catalog/Search` `OrderBy` instead of local re-sorting.
- Preserve existing behavior when the parameter is missing or invalid and keep performance by delegating sorting to PlayFab upstream.

### Description
- Added `resolveOrderBy` with a small allowlist of supported PlayFab fields and normalized `asc|desc` parsing, falling back to endpoint defaults when absent or invalid.
- Extended `fetchAllMarketplaceItemsEfficiently` to accept an `orderBy` parameter and pass it into `buildSearchPayload` so PlayFab performs the ordering upstream.
- Wired `orderBy` handling into service methods `fetchAll`, `fetchLatest`, `fetchPopular`, `fetchByTag`, and `fetchFree` so each endpoint computes an `orderBy` (or uses its existing default) and forwards it to PlayFab.
- Updated `src/controllers/marketplace/tagController.js` to forward `req.query` into `fetchByTag` so `orderBy` works for the tag endpoint as well.

### Testing
- Ran `node -e "require('./src/services/marketplaceService'); console.log('ok')"` to ensure the modified service loads without syntax/runtime errors and it succeeded.
- Attempted `npm test` which exited with `Error: no test specified` because the project has no configured test script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c5cfbaad88330896bcd97b4f9cf35)