### PR TITLE
Consider creation timestamp when detecting newly created items in ItemWatcher

### DIFF
--- a/src/services/itemWatcher.js
+++ b/src/services/itemWatcher.js
@@ -259,7 +259,7 @@ class ItemWatcher {
 
                 const prev = this.state.get(id) || null;
                 const isFirstSeen = !prev;
-                const looksRecentlyCreated = (startTs && startTs >= sinceTs) || (!startTs && creationTs && creationTs >= sinceTs);
+                const looksRecentlyCreated = (startTs && startTs >= sinceTs) || (creationTs && creationTs >= sinceTs);
                 const hasChanged = !prev || prev.hash !== nextHash;
                 const looksRecentlyUpdated = modTs && modTs >= sinceTs;
                 const isCreated = isFirstSeen && looksRecentlyCreated;


### PR DESCRIPTION
### Motivation
- Ensure items are marked as recently created when their `creationDate` is recent even if a `startDate` exists, because the previous logic ignored `creationDate` whenever `startDate` was present.

### Description
- Update `src/services/itemWatcher.js` to compute `looksRecentlyCreated` as `(startTs && startTs >= sinceTs) || (creationTs && creationTs >= sinceTs)` by removing the `!startTs` guard so the creation timestamp is considered regardless of a start timestamp.

### Testing
- Ran the existing automated test suite with `npm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2a1756a24833090d2afcc21cd6c3b)