### PR TITLE
Fix popular marketplace ranking by rating count

### DIFF
--- a/src/services/marketplaceService.js
+++ b/src/services/marketplaceService.js
@@ -332,7 +332,9 @@ function summarizeItem(it) {
 
 function ratingCountOf(it) {
     const r = it.Rating || it.rating || {};
-    return r.totalcount || r.TotalCount || r.count || r.Count || 0;
+    const value = r.totalcount ?? r.TotalCount ?? r.count ?? r.Count ?? 0;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function buildPriceBuckets(items) {
@@ -575,6 +577,13 @@ module.exports = {
         let items = await searchLoop(titleId, {filter, orderBy, batch: 300});
         items = await enrichWithFullItems(titleId, items);
         items = await enrichItemsWithResolvedReferences(titleId, items);
+        items.sort((a, b) => {
+            const diff = ratingCountOf(b) - ratingCountOf(a);
+            if (diff !== 0) return diff;
+            const bDate = Date.parse(b.StartDate || b.startDate || b.CreationDate || "") || 0;
+            const aDate = Date.parse(a.StartDate || a.startDate || a.CreationDate || "") || 0;
+            return bDate - aDate;
+        });
         return items;
     },
 


### PR DESCRIPTION
### Motivation
- The `/marketplace/popular` endpoint could return items in a non-deterministic order because upstream paged/concurrent fetches do not guarantee stable ordering by rating count.
- The rating count extraction also treated falsy values incorrectly and did not handle numeric strings robustly, which could cause incorrect ranking.

### Description
- Normalize `ratingCountOf` to use `??` and coerce the value with `Number(...)`, returning `0` for non-finite values to ensure a stable numeric rating count.
- After enrichment in `fetchPopular`, explicitly `sort` the items by rating count descending to enforce correct ordering regardless of upstream fetch order.
- Add a deterministic tie-breaker in the sort that orders items with equal rating counts by newest `StartDate` / `startDate` / `CreationDate` first.

### Testing
- Ran `node -e "require('./src/services/marketplaceService')"` to validate the module loads without runtime errors, and the command exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f43d06348330b386c4585d5d4606)