### PR TITLE
Concurrent fetching for Catalog/Search in `searchLoopAllItems` to reduce latency

### DIFF
--- a/src/services/marketplaceService.js
+++ b/src/services/marketplaceService.js
@@ -85,13 +85,40 @@ async function searchLoop(titleId, {
 async function searchLoopAllItems(titleId, {
     filter = "", orderBy = "creationDate desc", batch = 300, maxBatches = Number(process.env.MAX_SEARCH_BATCHES || 10)
 }) {
+    const batches = [];
+    let nextBatchIndex = 0;
+    let stopAtBatch = maxBatches;
+
+    async function worker() {
+        while (true) {
+            const batchIndex = nextBatchIndex;
+            nextBatchIndex += 1;
+            if (batchIndex >= stopAtBatch || batchIndex >= maxBatches) break;
+
+            const payload = buildSearchPayload({
+                filter,
+                search: "",
+                top: batch,
+                skip: batchIndex * batch,
+                orderBy
+            });
+            const data = await sendPlayFabRequest(titleId, "Catalog/Search", payload, "X-EntityToken", 3, OS);
+            const itemsRaw = data.Items || [];
+            batches[batchIndex] = itemsRaw;
+
+            if (itemsRaw.length < batch) {
+                const discoveredStop = batchIndex + 1;
+                if (discoveredStop < stopAtBatch) stopAtBatch = discoveredStop;
+            }
+        }
+    }
+
+    await Promise.all(Array.from({length: Math.max(1, FETCH_CONCURRENCY)}, () => worker()));
+
     const out = [];
-    for (let i = 0, skip = 0; i < maxBatches; i += 1, skip += batch) {
-        const payload = buildSearchPayload({filter, search: "", top: batch, skip, orderBy});
-        const data = await sendPlayFabRequest(titleId, "Catalog/Search", payload, "X-EntityToken", 3, OS);
-        const itemsRaw = data.Items || [];
-        out.push(...itemsRaw);
-        if (!itemsRaw.length || itemsRaw.length < batch) break;
+    const limit = Math.min(stopAtBatch, maxBatches);
+    for (let i = 0; i < limit; i += 1) {
+        out.push(...(batches[i] || []));
     }
     return out;
 }


### PR DESCRIPTION
### Motivation

- Replace a sequential, potentially slow loop over catalog search pages with a concurrent fetch approach to reduce overall latency when loading many items.
- Stop early when a page returns fewer items than the requested `batch` size to avoid unnecessary requests.
- Preserve the original ordered concatenation of search results while supporting configurable concurrency via `FETCH_CONCURRENCY` and `maxBatches`.

### Description

- Rewrote `searchLoopAllItems` to spawn worker tasks (count controlled by `FETCH_CONCURRENCY`) that concurrently call `sendPlayFabRequest` with `buildSearchPayload` and write results into a `batches` array by index. 
- Implemented `stopAtBatch` discovery when a fetched page returns fewer than `batch` items so workers can stop early. 
- After concurrent fetching completes, assemble the final results in order by iterating up to `Math.min(stopAtBatch, maxBatches)` and concatenating `batches[i]` into `out`.
- Left other helper functions and `searchLoop` unchanged.

### Testing

- Ran the automated unit test suite with `npm test`, and all tests passed.
- Ran linting with `npm run lint`, and there were no lint errors.
- Verified locally that catalog searches with large result sets return the same ordered results and complete faster under higher `FETCH_CONCURRENCY` values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ffad9d7883308040690fa2cc36ce)