### PR TITLE
Require authentication for `/marketplace/mc-token` route

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -307,7 +307,7 @@ app.use("/marketplace/resolve", enforceAuth, authLimiter, marketplaceLimiter, ca
 app.use("/marketplace/compare", enforceAuth, authLimiter, marketplaceLimiter, cacheHeaders(60, 300), mpCompare);
 app.use("/marketplace/featured-servers", enforceAuth, authLimiter, marketplaceLimiter, cacheHeaders(300, 1200), mpFeaturedServers);
 app.use("/marketplace/featured-content", enforceAuth, authLimiter, marketplaceLimiter, cacheHeaders(300, 1200), mpFeaturedPersona);
-app.use("/marketplace/mc-token", marketplaceLimiter, cacheHeaders(60, 300), mpMcToken);
+app.use("/marketplace/mc-token", enforceAuth, marketplaceLimiter, cacheHeaders(60, 300), mpMcToken);
 app.use("/marketplace/sales", enforceAuth, authLimiter, marketplaceLimiter, cacheHeaders(60, 300), mpSales);
 app.use("/marketplace/search/advanced", enforceAuth, authLimiter, marketplaceLimiter, mpSearchAdvanced);
 app.use("/marketplace/player/search", enforceAuth, authLimiter, marketplaceLimiter, cacheHeaders(30, 180), mpPlayerSearch);


### PR DESCRIPTION
### Motivation
- Close a security gap where the `/marketplace/mc-token` route was mounted without `enforceAuth`, allowing unauthenticated callers to obtain upstream Minecraft authorization tokens.

### Description
- Add `enforceAuth` to the `/marketplace/mc-token` route in `src/index.js` so it is protected like the other marketplace endpoints (`app.use("/marketplace/mc-token", enforceAuth, marketplaceLimiter, cacheHeaders(60, 300), mpMcToken);`).

### Testing
- Ran `node --check src/index.js` to verify the modified file parses correctly and the application entrypoint is valid (check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af323cd3188330a8daf9c033ab6227)