### PR TITLE
Fix catalog watcher pagination and add search contentType filters

### DIFF
--- a/PlayFab Service - VMC.postman_collection.json
+++ b/PlayFab Service - VMC.postman_collection.json
@@ -2142,7 +2142,8 @@
                 },
                 "description": "Return marketplace items for a tag."
               },
-              "response": []
+              "response": [],
+              "description": "Return marketplace items for a tag."
             }
           ],
           "description": "Latest, popular, free, and tag-based discovery."
@@ -2180,7 +2181,7 @@
                   }
                 ],
                 "url": {
-                  "raw": "{{baseUrl}}/marketplace/search/{{alias_prod}}?creatorName={{creator1}}&keyword={{keyword}}",
+                  "raw": "{{baseUrl}}/marketplace/search/{{alias_prod}}?creatorName={{creator1}}&keyword={{keyword}}&contentType={{contentType}}",
                   "host": [
                     "{{baseUrl}}"
                   ],
@@ -2263,12 +2264,18 @@
                       "value": "{{dateTo}}",
                       "disabled": true,
                       "description": "Filter items with StartDate <= this ISO date."
+                    },
+                    {
+                      "key": "contentType",
+                      "value": "{{contentType}}",
+                      "description": "Exact PlayFab ContentType, for example 3PServerContent_V1.2."
                     }
                   ]
                 },
                 "description": "Search items by creator and keyword."
               },
-              "response": []
+              "response": [],
+              "description": "Search items by creator, keyword, and optional contentType."
             },
             {
               "name": "POST /marketplace/search/advanced/:alias - keyword only",
@@ -2435,7 +2442,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"filters\": {\n    \"tagsAny\": [\"{{tag}}\"],\n    \"priceAmounts\": {\n      \"min\": 0,\n      \"max\": 5000\n    },\n    \"ratingMin\": 3\n  }\n}",
+                  "raw": "{\n  \"filters\": {\n    \"tagsAny\": [\n      \"{{tag}}\"\n    ],\n    \"priceAmounts\": {\n      \"min\": 0,\n      \"max\": 5000\n    },\n    \"ratingMin\": 3,\n    \"contentType\": \"{{contentType}}\"\n  }\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2466,7 +2473,8 @@
                 },
                 "description": "Advanced search with common filters."
               },
-              "response": []
+              "response": [],
+              "description": "Advanced search with common filters, including exact contentType."
             },
             {
               "name": "POST /marketplace/player/search/:alias",
@@ -2501,7 +2509,7 @@
                 ],
                 "body": {
                   "mode": "raw",
-                  "raw": "{\n  \"titleEntityToken\": \"{{titleEntityToken}}\",\n  \"titlePlayerAccountId\": \"{{titlePlayerAccountId}}\",\n  \"search\": \"{{keyword}}\",\n  \"creatorName\": \"{{creator1}}\",\n  \"top\": 25,\n  \"skip\": 0,\n  \"creationDateFrom\": \"{{dateFrom}}\",\n  \"creationDateTo\": \"{{dateTo}}\",\n  \"lastModifiedDateFrom\": \"{{dateFrom}}\",\n  \"lastModifiedDateTo\": \"{{dateTo}}\",\n  \"startDateFrom\": \"{{dateFrom}}\",\n  \"startDateTo\": \"{{dateTo}}\"\n}",
+                  "raw": "{\n  \"titleEntityToken\": \"{{titleEntityToken}}\",\n  \"titlePlayerAccountId\": \"{{titlePlayerAccountId}}\",\n  \"search\": \"{{keyword}}\",\n  \"creatorName\": \"{{creator1}}\",\n  \"top\": 25,\n  \"skip\": 0,\n  \"creationDateFrom\": \"{{dateFrom}}\",\n  \"creationDateTo\": \"{{dateTo}}\",\n  \"lastModifiedDateFrom\": \"{{dateFrom}}\",\n  \"lastModifiedDateTo\": \"{{dateTo}}\",\n  \"startDateFrom\": \"{{dateFrom}}\",\n  \"startDateTo\": \"{{dateTo}}\",\n  \"contentType\": \"{{contentType}}\"\n}",
                   "options": {
                     "raw": {
                       "language": "json"
@@ -2522,7 +2530,8 @@
                 },
                 "description": "Search the player marketplace with entity tokens and optional filters."
               },
-              "response": []
+              "response": [],
+              "description": "Search the player marketplace with entity tokens, creatorName, keyword, dates, and optional contentType."
             }
           ],
           "description": "Basic, advanced, and player marketplace search."
@@ -3873,6 +3882,11 @@
     {
       "key": "dateTo",
       "value": "2026-12-31T23:59:59Z",
+      "type": "string"
+    },
+    {
+      "key": "contentType",
+      "value": "3PServerContent_V1.2",
       "type": "string"
     }
   ],

--- a/readme.md
+++ b/readme.md
@@ -607,7 +607,7 @@ Not allowed (returns `400`):
 
 * `/events/stream` (optional query `events=<comma-separated-event-names>`):
   `item.snapshot`, `item.created`, `item.updated`, `sale.snapshot`, `sale.update`, `price.changed`, `creator.trending`, `featured.content.updated`.
-* `featured.content.updated` includes changed `/marketplace/featured-content` layout entries in `addedItems` / `removedItems`. `addedItemDetails` / `removedItemDetails` contain the same endpoint item details plus `featuredContext` (`page`, `row`, `component`, `itemIndex`); `currentItemDetails` and `previousItemDetails` provide the full after/before featured item lists.
+* `featured.content.updated` includes changed `/marketplace/featured-content` layout entries in `addedItems`, `removedItems`, and `changedItems`. `addedItemDetails`, `removedItemDetails`, and `changedItemDetails` contain the same endpoint item details plus `featuredContext` (`page`, `row`, `component`, `itemIndex`); `currentItemDetails` and `previousItemDetails` provide the full after/before featured item lists. Same-ID layout or metadata changes set `contentChanged=true` and include `previousContentSignature` / `currentContentSignature`.
 
 #### Admin Webhooks
 

--- a/readme.md
+++ b/readme.md
@@ -451,10 +451,11 @@ Filter by tag; fully enriched items (optionally with references).
 
 Creator is resolved via `creators.json` (matches `creatorName` or `displayName`, whitespace-insensitive).
 
-#### Date filters on item endpoints
+#### Content type and date filters on search endpoints
 
-Item list endpoints accept ISO date ranges for PlayFab catalog timestamps: `creationDateFrom`/`creationDateTo`, `lastModifiedDateFrom`/`lastModifiedDateTo`, and `startDateFrom`/`startDateTo`.
-These filters are pushed into PlayFab search where possible and can be combined with pagination, creator, tag, free, popular, latest, summary, compare, player marketplace search, recommendations, and sales item queries.
+Search endpoints accept `contentType=<PlayFab ContentType>` for exact PlayFab `ContentType` matches, for example `contentType=3PServerContent_V1.2`.
+Item list/search endpoints also accept ISO date ranges for PlayFab catalog timestamps: `creationDateFrom`/`creationDateTo`, `lastModifiedDateFrom`/`lastModifiedDateTo`, and `startDateFrom`/`startDateTo`.
+Date filters are pushed into PlayFab search where possible and can be combined with pagination, creator, tag, free, popular, latest, summary, compare, player marketplace search, recommendations, and sales item queries.
 
 #### `GET /marketplace/details/:alias/:itemId?expand=prices,reviews,refs`
 
@@ -539,6 +540,7 @@ Unknown fields are rejected with **400 Bad Request**.
     "tags": ["hidden_offer", "3P"],
     "tagsAny": ["3P", "server"],
     "tagsAll": ["marketplace", "hidden_offer"],
+    "contentType": "3PServerContent_V1.2",
     "contentKinds": ["world"],
     "creationDate": { "from": "2026-02-01T00:00:00Z", "to": "2026-02-28T23:59:59Z" },
     "lastModifiedDate": { "from": "2026-02-01T00:00:00Z", "to": "2026-02-28T23:59:59Z" },
@@ -570,6 +572,7 @@ The following filters are pushed directly to PlayFab OData in `Catalog/Search`:
 * `isStackable`
 * `platforms`
 * `tags`, `tagsAny`, `tagsAll`
+* `contentType`, `contentTypes`
 * `contentKinds` (`skinpack`, `world`, `persona`, `addon`, `resourcepack`, `mashup`)
 * `creationDate`, `lastModifiedDate`, `startDate`
 * `priceAmounts.min/max` (via `DisplayProperties/price`)
@@ -589,7 +592,7 @@ The following filters are additionally evaluated in the API layer (when PlayFab 
 Allowed sort fields:
 
 * `id`, `type`, `title`, `description`, `keywords`
-* `isStackable`, `platforms`, `tags`
+* `contentType`, `isStackable`, `platforms`, `tags`
 * `creationDate`, `lastModifiedDate`, `startDate`
 * `priceAmount`, `creatorName`, `purchasable`, `packIdentityType`
 

--- a/src/docs/openapi-base.yaml
+++ b/src/docs/openapi-base.yaml
@@ -469,6 +469,18 @@ components:
                 - type: array
                   items:
                     type: string
+            contentType:
+              oneOf:
+                - type: string
+                - type: array
+                  items:
+                    type: string
+            contentTypes:
+              oneOf:
+                - type: string
+                - type: array
+                  items:
+                    type: string
             contentKinds:
               oneOf:
                 - type: string
@@ -480,6 +492,8 @@ components:
                       - world
                       - persona
                       - addon
+                      - resourcepack
+                      - mashup
             creationDate:
               type: object
               additionalProperties: false
@@ -544,6 +558,7 @@ components:
                 enum:
                   - id
                   - type
+                  - contentType
                   - title
                   - description
                   - keywords

--- a/src/docs/paths/marketplace.player-search.yaml
+++ b/src/docs/paths/marketplace.player-search.yaml
@@ -42,6 +42,9 @@
                 type: string
               creatorName:
                 type: string
+              contentType:
+                type: string
+                description: Exact PlayFab `ContentType`, for example `3PServerContent_V1.2`.
               filter:
                 type: string
               creationDateFrom:

--- a/src/docs/paths/marketplace.search.yaml
+++ b/src/docs/paths/marketplace.search.yaml
@@ -35,6 +35,12 @@
         schema:
           type: string
       - in: query
+        name: contentType
+        required: false
+        schema:
+          type: string
+        description: Exact PlayFab `ContentType`, for example `3PServerContent_V1.2`.
+      - in: query
         name: creationDateFrom
         required: false
         schema:

--- a/src/docs/schemas/AdvancedSearchRequest.yaml
+++ b/src/docs/schemas/AdvancedSearchRequest.yaml
@@ -83,6 +83,18 @@ AdvancedSearchRequest:
             - type: array
               items:
                 type: string
+        contentType:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+        contentTypes:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
         contentKinds:
           oneOf:
             - type: string
@@ -94,6 +106,8 @@ AdvancedSearchRequest:
                   - world
                   - persona
                   - addon
+                  - resourcepack
+                  - mashup
         creationDate:
           type: object
           additionalProperties: false
@@ -158,6 +172,7 @@ AdvancedSearchRequest:
             enum:
               - id
               - type
+              - contentType
               - title
               - description
               - keywords

--- a/src/routes/marketplace/player-search.js
+++ b/src/routes/marketplace/player-search.js
@@ -26,6 +26,7 @@ router.post(
         body("masterEntityToken").optional().isString().isLength({min: 1, max: 4096}),
         body("titlePlayerAccountId").optional().isString().isLength({min: 1, max: 200}),
         body("creatorName").optional().isString().isLength({max: 200}),
+        body("contentType").optional().isString().isLength({max: 200}),
         body("filter").optional().isString().isLength({max: 2000}),
         body("creationDateFrom").optional().isISO8601(),
         body("creationDateTo").optional().isISO8601(),

--- a/src/routes/marketplace/search-advanced.js
+++ b/src/routes/marketplace/search-advanced.js
@@ -37,6 +37,8 @@ router.post(
         body("filters.tags").optional().custom(v => typeof v === "string" || Array.isArray(v)),
         body("filters.tagsAny").optional().custom(v => typeof v === "string" || Array.isArray(v)),
         body("filters.tagsAll").optional().custom(v => typeof v === "string" || Array.isArray(v)),
+        body("filters.contentType").optional().custom(v => typeof v === "string" || Array.isArray(v)),
+        body("filters.contentTypes").optional().custom(v => typeof v === "string" || Array.isArray(v)),
         body("filters.contentKinds").optional().custom(v => typeof v === "string" || Array.isArray(v)),
         body("filters.creationDate").optional().isObject(),
         body("filters.creationDate.from").optional().isISO8601(),

--- a/src/routes/marketplace/search.js
+++ b/src/routes/marketplace/search.js
@@ -29,6 +29,7 @@ router.get(
         check("skip").optional().isInt({min: 0}),
         check("limit").optional().isInt({min: 1, max: 1000}),
         check("orderBy").optional().isString().isLength({max: 200}),
+        check("contentType").optional().isString().isLength({max: 200}),
         ...dateQuery
     ],
     validate,

--- a/src/services/advancedSearchService.js
+++ b/src/services/advancedSearchService.js
@@ -14,6 +14,7 @@
 
 const {resolveTitle} = require("../utils/titles");
 const {sendPlayFabRequest, buildSearchPayload, isValidItem, transformItem} = require("../utils/playfab");
+const {buildContentTypeFilter} = require("../utils/filter");
 
 const PAGE_BATCH = Math.max(100, parseInt(process.env.ADV_SEARCH_BATCH || "300", 10));
 const MAX_BATCHES = Math.max(1, parseInt(process.env.ADV_SEARCH_MAX_BATCHES || "120", 10));
@@ -143,6 +144,8 @@ function validateRequestBody(body) {
         "tags",
         "tagsAny",
         "tagsAll",
+        "contentType",
+        "contentTypes",
         "contentKinds",
         "ratingMin",
         "creationDate",
@@ -309,6 +312,13 @@ function buildPlayFabFilter(filters) {
     const tagsAll = normalizeArray(filters.tagsAll);
     if (tagsAll.length) clauses.push(buildContainsAllFilter("tags", tagsAll, "tb"));
 
+    const contentTypes = [
+        ...normalizeArray(filters.contentType),
+        ...normalizeArray(filters.contentTypes)
+    ];
+    const contentTypeClause = buildContentTypeFilter(contentTypes);
+    if (contentTypeClause) clauses.push(contentTypeClause);
+
     const contentKindClause = buildContentKindFilter(filters.contentKinds);
     if (contentKindClause) clauses.push(contentKindClause);
 
@@ -426,6 +436,7 @@ function parseSort(sort) {
     const playFabFields = {
         id: "Id",
         type: "Type",
+        contenttype: "ContentType",
         creationdate: "CreationDate",
         lastmodifieddate: "LastModifiedDate",
         startdate: "StartDate",
@@ -436,6 +447,7 @@ function parseSort(sort) {
     const localFieldExtractors = {
         id: it => String(it?.Id || ""),
         type: it => String(it?.Type || ""),
+        contenttype: it => String(it?.ContentType || it?.contentType || ""),
         title: it => String(it?.Title?.NEUTRAL || ""),
         description: it => String(it?.Description?.NEUTRAL || ""),
         keywords: it => extractKeywordValues(it).sort()[0] || "",

--- a/src/services/featuredContentWatcher.js
+++ b/src/services/featuredContentWatcher.js
@@ -357,6 +357,7 @@ module.exports = {
         collectFeaturedItems,
         uniqueIdsFromItems,
         uniqueIdsFromEntries,
+        featuredContentSignature,
         buildFeaturedContentChangePayload
     }
 };

--- a/src/services/featuredContentWatcher.js
+++ b/src/services/featuredContentWatcher.js
@@ -181,6 +181,8 @@ function buildFeaturedContentChangePayload({
                                                previousItems,
                                                currentItems,
                                                content,
+                                               previousContentSignature,
+                                               currentContentSignature,
                                                ts = Date.now()
                                            }) {
     const prevEntries = previousEntries || (previousItems || []).map(item => ({id: featuredItemId(item), item}));
@@ -193,12 +195,16 @@ function buildFeaturedContentChangePayload({
     const addedItemIds = currentItemIds.filter(id => !previousSet.has(id));
     const removedItemIds = previousItemIds.filter(id => !currentSet.has(id));
 
-    if (!addedItemIds.length && !removedItemIds.length) return null;
-
     const previousMap = entryMapById(prevEntries);
     const currentMap = entryMapById(currEntries);
+    const changedItemIds = changedIdsFromEntryMaps(previousItemIds, previousMap, currentMap);
+    const contentChanged = Boolean(previousContentSignature && currentContentSignature && previousContentSignature !== currentContentSignature);
+
+    if (!addedItemIds.length && !removedItemIds.length && !changedItemIds.length && !contentChanged) return null;
+
     const addedEntries = entriesForIds(addedItemIds, currentMap);
     const removedEntries = entriesForIds(removedItemIds, previousMap);
+    const changedEntries = entriesForIds(changedItemIds, currentMap);
     const currentEntriesOrdered = entriesForIds(currentItemIds, currentMap);
     const previousEntriesOrdered = entriesForIds(previousItemIds, previousMap);
 
@@ -207,14 +213,20 @@ function buildFeaturedContentChangePayload({
         titleId,
         addedItemIds,
         removedItemIds,
+        changedItemIds,
         addedItems: addedEntries.map(entry => entry.item),
         removedItems: removedEntries.map(entry => entry.item),
+        changedItems: changedEntries.map(entry => entry.item),
         addedItemDetails: detailsFromEntries(addedEntries),
         removedItemDetails: detailsFromEntries(removedEntries),
+        changedItemDetails: detailsFromEntries(changedEntries),
         currentItemIds,
         previousItemIds,
         currentItemDetails: detailsFromEntries(currentEntriesOrdered),
         previousItemDetails: detailsFromEntries(previousEntriesOrdered),
+        contentChanged,
+        previousContentSignature: previousContentSignature || null,
+        currentContentSignature: currentContentSignature || null,
         content
     };
 }

--- a/src/services/featuredContentWatcher.js
+++ b/src/services/featuredContentWatcher.js
@@ -14,6 +14,7 @@
 
 const logger = require("../config/logger");
 const {resolveTitle} = require("../utils/titles");
+const {stableHash} = require("../utils/hash");
 const {fetchFeaturedPersona} = require("./featuredPersonaService");
 
 function featuredItemId(item) {
@@ -160,6 +161,36 @@ function entryMapById(entries) {
 
 function entriesForIds(ids, entryMap) {
     return (ids || []).map(id => entryMap.get(normalizeId(id))).filter(Boolean);
+}
+
+function signatureEntry(entry) {
+    return {
+        id: normalizeId(entry?.id || featuredItemId(entry?.item)),
+        item: entry?.item || null,
+        itemIndex: typeof entry?.itemIndex === "number" ? entry.itemIndex : null,
+        page: entry?.page || null,
+        row: entry?.row || null,
+        component: entry?.component || null
+    };
+}
+
+function entrySignature(entry) {
+    return stableHash(signatureEntry(entry));
+}
+
+function featuredContentSignature(payload, entries) {
+    return stableHash({
+        content: payload || null,
+        entries: (entries || []).map(signatureEntry)
+    });
+}
+
+function changedIdsFromEntryMaps(previousItemIds, previousMap, currentMap) {
+    return (previousItemIds || []).filter(id => {
+        const normalizedId = normalizeId(id);
+        if (!normalizedId || !currentMap.has(normalizedId)) return false;
+        return entrySignature(previousMap.get(normalizedId)) !== entrySignature(currentMap.get(normalizedId));
+    });
 }
 
 function detailsFromEntries(entries) {

--- a/src/services/featuredContentWatcher.js
+++ b/src/services/featuredContentWatcher.js
@@ -248,6 +248,7 @@ class FeaturedContentWatcher {
         this.timer = null;
         this.lastItemIds = null;
         this.lastEntries = [];
+        this.lastContentSignature = null;
     }
 
     start(eventBus) {
@@ -263,27 +264,33 @@ class FeaturedContentWatcher {
                 const entries = collectFeaturedItemEntries(payload);
                 const currentItemIds = uniqueIdsFromEntries(entries);
                 const currentItemIdsSet = new Set(currentItemIds);
+                const currentContentSignature = featuredContentSignature(payload, entries);
 
                 if (!this.lastItemIds) {
                     this.lastItemIds = currentItemIdsSet;
                     this.lastEntries = entries;
+                    this.lastContentSignature = currentContentSignature;
                     return;
                 }
 
                 const previousItemIds = Array.from(this.lastItemIds);
                 const addedItemIds = currentItemIds.filter(id => !this.lastItemIds.has(id));
                 const removedItemIds = previousItemIds.filter(id => !currentItemIdsSet.has(id));
+                const contentChanged = this.lastContentSignature !== currentContentSignature;
 
-                if (addedItemIds.length || removedItemIds.length) {
+                if (addedItemIds.length || removedItemIds.length || contentChanged) {
                     const eventPayload = buildFeaturedContentChangePayload({
                         titleId,
                         previousEntries: this.lastEntries,
                         currentEntries: entries,
+                        previousContentSignature: this.lastContentSignature,
+                        currentContentSignature,
                         content: payload
                     });
 
                     this.lastItemIds = currentItemIdsSet;
                     this.lastEntries = entries;
+                    this.lastContentSignature = currentContentSignature;
 
                     if (eventPayload) {
                         eventBus.emit("featured.content.updated", eventPayload);
@@ -293,6 +300,7 @@ class FeaturedContentWatcher {
 
                 this.lastItemIds = currentItemIdsSet;
                 this.lastEntries = entries;
+                this.lastContentSignature = currentContentSignature;
             } catch (e) {
                 logger.debug(`[FeaturedContentWatcher] error ${e.message || "err"}`);
             }

--- a/src/services/itemWatcher.js
+++ b/src/services/itemWatcher.js
@@ -77,23 +77,35 @@ async function fetchRecentItems(titleId, os, itemsPerRequest, maxItems) {
     const orderBy = `${field} desc`;
     const filter = "";
 
+    return collectPaginatedItems(itemsPerRequest, maxItems, (continuationToken, count) => requestItems(titleId, os, filter, orderBy, continuationToken, count));
+}
+
+function shouldFetchNextPage(nextToken, previousToken, seenTokens) {
+    if (!nextToken) return false;
+    if (nextToken === previousToken) return false;
+    if (seenTokens && seenTokens.has(nextToken)) return false;
+    if (seenTokens) seenTokens.add(nextToken);
+    return true;
+}
+
+async function collectPaginatedItems(itemsPerRequest, maxItems, loadPage) {
     const allItems = [];
     let continuationToken = null;
+    const seenContinuationTokens = new Set();
 
     while (allItems.length < maxItems) {
         const remaining = maxItems - allItems.length;
         const count = Math.min(itemsPerRequest, remaining);
-        const page = await requestItems(titleId, os, filter, orderBy, continuationToken, count);
-
+        const page = await loadPage(continuationToken, count);
         const pageItems = page.items || [];
-        if (!pageItems.length) break;
+        const previousToken = continuationToken;
 
         allItems.push(...pageItems);
         continuationToken = page.continuationToken || null;
-        if (!continuationToken) break;
+        if (!shouldFetchNextPage(continuationToken, previousToken, seenContinuationTokens)) break;
     }
 
-    return allItems;
+    return allItems.slice(0, maxItems);
 }
 
 function normalizeFieldSpec(field) {
@@ -170,13 +182,13 @@ async function requestItems(titleId, os, filter, orderBy, continuationToken, cou
     const data = await searchItemsPage(titleId, os, filter, orderBy, continuationToken, count);
     const hits = data.Items || data.items || [];
     const nextToken = data.ContinuationToken || data.continuationToken || null;
-    if (!hits.length) return {items: [], continuationToken: nextToken};
+    if (!hits.length) return {items: [], continuationToken: nextToken, hitCount: 0};
 
     const ids = hits.map(idOfSearchHit).filter(Boolean);
     const full = await getItemsCompat(titleId, os, ids);
     const fallbackItems = hits.map(itemFromSearchHit).filter(Boolean);
     const items = ((full && full.length) ? full : fallbackItems).filter(isValidItem);
-    return {items, continuationToken: nextToken};
+    return {items, continuationToken: nextToken, hitCount: hits.length};
 }
 
 async function fetchItemsSince(titleId, os, field, sinceIso, itemsPerRequest, maxItems) {
@@ -187,22 +199,9 @@ async function fetchItemsSince(titleId, os, field, sinceIso, itemsPerRequest, ma
     for (const f of candidates) {
         const filter = `(${f} ge ${toFilterDateLiteral(sinceIso)})`;
         const orderBy = `${f} asc`;
-        const allItems = [];
-        let continuationToken = null;
 
         try {
-            while (allItems.length < maxItems) {
-                const remaining = maxItems - allItems.length;
-                const count = Math.min(itemsPerRequest, remaining);
-                const page = await requestItems(titleId, os, filter, orderBy, continuationToken, count);
-                const pageItems = page.items || [];
-                if (!pageItems.length) break;
-                allItems.push(...pageItems);
-                if (pageItems.length < count) break;
-                continuationToken = page.continuationToken || null;
-                if (!continuationToken) break;
-            }
-            return allItems;
+            return await collectPaginatedItems(itemsPerRequest, maxItems, (continuationToken, count) => requestItems(titleId, os, filter, orderBy, continuationToken, count));
         } catch (e) {
             lastErr = e;
         }
@@ -375,6 +374,8 @@ module.exports = {
     _internals: {
         classifyItemChange,
         parseFallbackOffset,
-        makeFallbackOffset
+        makeFallbackOffset,
+        shouldFetchNextPage,
+        collectPaginatedItems
     }
 };

--- a/src/services/itemWatcher.js
+++ b/src/services/itemWatcher.js
@@ -18,6 +18,7 @@ const {resolveTitle} = require("../utils/titles");
 const {stableHash} = require("../utils/hash");
 const {projectCatalogItems, projectCatalogItem} = require("../utils/projectors");
 const SEARCH_ITEMS_MAX_COUNT = 50;
+let searchItemsUnavailable = false;
 
 function getTitleId() {
     const alias = (process.env.FEATURED_PRIMARY_ALIAS || process.env.DEFAULT_ALIAS || "").trim();
@@ -91,18 +92,22 @@ function shouldFetchNextPage(nextToken, previousToken, seenTokens) {
 async function collectPaginatedItems(itemsPerRequest, maxItems, loadPage) {
     const allItems = [];
     let continuationToken = null;
+    let scannedHits = 0;
     const seenContinuationTokens = new Set();
 
-    while (allItems.length < maxItems) {
-        const remaining = maxItems - allItems.length;
+    while (scannedHits < maxItems) {
+        const remaining = maxItems - scannedHits;
         const count = Math.min(itemsPerRequest, remaining);
         const page = await loadPage(continuationToken, count);
         const pageItems = page.items || [];
         const previousToken = continuationToken;
+        const hitCount = Number.isFinite(page.hitCount) ? page.hitCount : pageItems.length;
 
+        scannedHits += Math.max(0, hitCount);
         allItems.push(...pageItems);
         continuationToken = page.continuationToken || null;
         if (!shouldFetchNextPage(continuationToken, previousToken, seenContinuationTokens)) break;
+        if (hitCount <= 0) break;
     }
 
     return allItems.slice(0, maxItems);
@@ -132,26 +137,35 @@ async function searchItemsPage(titleId, os, filter, orderBy, continuationToken, 
         Filter: filter, OrderBy: orderBy, ContinuationToken: continuationToken, Count: safeCount
     };
 
+    if (searchItemsUnavailable) {
+        return await searchItemsPageFallback(titleId, os, filter, orderBy, continuationToken, safeCount);
+    }
+
     try {
         const data = await sendPlayFabRequest(titleId, "Catalog/SearchItems", payload, "X-EntityToken", 3, os);
         return data || {};
     } catch (err) {
-        const offset = parseFallbackOffset(continuationToken);
-        logger.warn(`[ItemWatcher] Catalog/SearchItems failed, falling back to Catalog/Search: ${err.message}`);
-        const data = await sendPlayFabRequest(titleId, "Catalog/Search", {
-            Filter: filter,
-            OrderBy: orderBy,
-            Top: safeCount,
-            Skip: offset,
-            Expand: "Images"
-        }, "X-EntityToken", 3, os);
-
-        const items = data?.Items || data?.items || [];
-        return {
-            Items: items,
-            ContinuationToken: items.length >= safeCount ? makeFallbackOffset(offset + items.length) : null
-        };
+        searchItemsUnavailable = true;
+        logger.warn(`[ItemWatcher] Catalog/SearchItems failed, falling back to Catalog/Search for this process: ${err.message}`);
+        return await searchItemsPageFallback(titleId, os, filter, orderBy, continuationToken, safeCount);
     }
+}
+
+async function searchItemsPageFallback(titleId, os, filter, orderBy, continuationToken, safeCount) {
+    const offset = parseFallbackOffset(continuationToken);
+    const data = await sendPlayFabRequest(titleId, "Catalog/Search", {
+        Filter: filter,
+        OrderBy: orderBy,
+        Top: safeCount,
+        Skip: offset,
+        Expand: "Images"
+    }, "X-EntityToken", 3, os);
+
+    const items = data?.Items || data?.items || [];
+    return {
+        Items: items,
+        ContinuationToken: items.length >= safeCount ? makeFallbackOffset(offset + items.length) : null
+    };
 }
 
 function parseFallbackOffset(token) {
@@ -376,6 +390,7 @@ module.exports = {
         parseFallbackOffset,
         makeFallbackOffset,
         shouldFetchNextPage,
-        collectPaginatedItems
+        collectPaginatedItems,
+        searchItemsPageFallback
     }
 };

--- a/src/services/marketplaceService.js
+++ b/src/services/marketplaceService.js
@@ -26,7 +26,7 @@ const {
 } = require("../utils/playfab");
 const {resolveTitle} = require("../utils/titles");
 const {loadCreators, resolveCreatorId} = require("../utils/creators");
-const {buildFilter, buildDateFilter, filterItemsByDate} = require("../utils/filter");
+const {buildFilter, buildDateFilter, buildContentTypeFilter, filterItemsByDate} = require("../utils/filter");
 const {resolveMarketplaceEntityInput} = require("../utils/marketplaceTokens");
 const {buildPlayerMarketplaceFilter} = require("../utils/marketplaceFilters");
 const featuredServers = require("../config/featuredServers");
@@ -559,8 +559,8 @@ module.exports = {
     async search(alias, creatorName, keyword, query = {}) {
         const titleId = resolveTitle(alias);
         const {params, top, skip} = resolveCatalogPagination(query, PAGE_SIZE, PAGE_SIZE);
-        const cid = resolveCreatorId(creatorsArr, creatorName);
-        const filter = `creatorId eq '${cid.replace(/'/g, "''")}'`;
+        const baseFilter = buildFilter({query: {...query, creatorName}}, creatorsArr);
+        const filter = andFilter(baseFilter, buildContentTypeFilter(query.contentType));
         const orderBy = resolveOrderBy(query.orderBy, "creationDate desc");
         const payload = buildSearchPayload({
             filter, search: `"${keyword}"`, top, skip, orderBy
@@ -598,7 +598,7 @@ module.exports = {
         const top = Number.isFinite(topRaw) && topRaw > 0 ? Math.min(topRaw, 300) : 100;
         const skip = Number.isFinite(skipRaw) && skipRaw >= 0 ? skipRaw : 0;
         const creatorFilter = buildPlayerMarketplaceFilter(payload.filter, payload.creatorName, creatorsArr);
-        const filter = andFilter(creatorFilter, buildDateFilter(payload));
+        const filter = andFilter(andFilter(creatorFilter, buildContentTypeFilter(payload.contentType)), buildDateFilter(payload));
         const payloadSearch = buildSearchPayload({
             filter,
             search: typeof payload.search === "string" ? payload.search : "",

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -38,6 +38,23 @@ function buildDateFilter(query = {}) {
     return parts.join(" and ");
 }
 
+function quotePlayFabString(value) {
+    return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function normalizeStringList(value) {
+    if (Array.isArray(value)) return value.map(v => String(v || "").trim()).filter(Boolean);
+    if (typeof value === "string" && value.trim()) return [value.trim()];
+    return [];
+}
+
+function buildContentTypeFilter(value) {
+    const values = normalizeStringList(value);
+    if (!values.length) return "";
+    const parts = values.map(contentType => `ContentType eq ${quotePlayFabString(contentType)}`);
+    return parts.length === 1 ? parts[0] : `(${parts.join(" or ")})`;
+}
+
 function buildFilter(req, creators, extra = "") {
     const parts = [];
     if (req.query.creatorName) {
@@ -73,4 +90,4 @@ function filterItemsByDate(items, query = {}) {
     return items.filter(item => matchesDateFilters(item, query));
 }
 
-module.exports = {buildFilter, buildDateFilter, filterItemsByDate};
+module.exports = {buildFilter, buildDateFilter, buildContentTypeFilter, filterItemsByDate};

--- a/test/featuredContentWatcher.test.js
+++ b/test/featuredContentWatcher.test.js
@@ -117,3 +117,44 @@ test("buildFeaturedContentChangePayload returns null when the featured item set 
 
     assert.equal(payload, null);
 });
+
+test("featuredContentSignature changes when featured content metadata changes with the same ids", () => {
+    const previousPayload = featuredPayload([layoutItem("one", "One")]);
+    const currentPayload = featuredPayload([layoutItem("one", "One Updated")]);
+    const previousEntries = _internals.collectFeaturedItemEntries(previousPayload);
+    const currentEntries = _internals.collectFeaturedItemEntries(currentPayload);
+
+    const previousSignature = _internals.featuredContentSignature(previousPayload, previousEntries);
+    const currentSignature = _internals.featuredContentSignature(currentPayload, currentEntries);
+
+    assert.notEqual(previousSignature, currentSignature);
+});
+
+test("buildFeaturedContentChangePayload emits same-id featured content changes", () => {
+    const previousPayload = featuredPayload([layoutItem("one", "One")]);
+    const currentPayload = featuredPayload([layoutItem("one", "One Updated")]);
+    const previousEntries = _internals.collectFeaturedItemEntries(previousPayload);
+    const currentEntries = _internals.collectFeaturedItemEntries(currentPayload);
+    const previousContentSignature = _internals.featuredContentSignature(previousPayload, previousEntries);
+    const currentContentSignature = _internals.featuredContentSignature(currentPayload, currentEntries);
+
+    const payload = _internals.buildFeaturedContentChangePayload({
+        titleId: "20CA2",
+        previousEntries,
+        currentEntries,
+        previousContentSignature,
+        currentContentSignature,
+        content: currentPayload,
+        ts: 456
+    });
+
+    assert.equal(payload.ts, 456);
+    assert.equal(payload.contentChanged, true);
+    assert.equal(payload.previousContentSignature, previousContentSignature);
+    assert.equal(payload.currentContentSignature, currentContentSignature);
+    assert.deepEqual(payload.addedItemIds, []);
+    assert.deepEqual(payload.removedItemIds, []);
+    assert.deepEqual(payload.changedItemIds, ["one"]);
+    assert.deepEqual(payload.changedItems, [layoutItem("one", "One Updated")]);
+    assert.equal(payload.changedItemDetails[0].featuredContext.row.telemetryId, "dr.header.featured");
+});

--- a/test/itemWatcher.test.js
+++ b/test/itemWatcher.test.js
@@ -133,6 +133,34 @@ test("fallback offset helpers clamp invalid offsets to zero", () => {
     assert.equal(_internals.parseFallbackOffset("bogus"), 0);
 });
 
+test("pagination continues when a partial detail page has a continuation token", async () => {
+    const pages = [
+        {items: [{Id: "item-1"}], continuationToken: "page-2"},
+        {items: [{Id: "item-2"}], continuationToken: null}
+    ];
+    const requestedTokens = [];
+
+    const result = await _internals.collectPaginatedItems(5, 10, async continuationToken => {
+        requestedTokens.push(continuationToken);
+        return pages.shift();
+    });
+
+    assert.deepEqual(requestedTokens, [null, "page-2"]);
+    assert.deepEqual(result.map(item => item.Id), ["item-1", "item-2"]);
+});
+
+test("pagination stops on repeated continuation tokens", async () => {
+    let calls = 0;
+
+    const result = await _internals.collectPaginatedItems(5, 10, async () => {
+        calls += 1;
+        return {items: [{Id: `item-${calls}`}], continuationToken: "same-token"};
+    });
+
+    assert.equal(calls, 2);
+    assert.deepEqual(result.map(item => item.Id), ["item-1", "item-2"]);
+});
+
 test("classifyItemChange returns a stable hash for known items", () => {
     const result = _internals.classifyItemChange(makeItem(), null, SINCE_TS);
     assert.equal(typeof result.nextHash, "string");

--- a/test/itemWatcher.test.js
+++ b/test/itemWatcher.test.js
@@ -135,8 +135,8 @@ test("fallback offset helpers clamp invalid offsets to zero", () => {
 
 test("pagination continues when a partial detail page has a continuation token", async () => {
     const pages = [
-        {items: [{Id: "item-1"}], continuationToken: "page-2"},
-        {items: [{Id: "item-2"}], continuationToken: null}
+        {items: [{Id: "item-1"}], continuationToken: "page-2", hitCount: 5},
+        {items: [{Id: "item-2"}], continuationToken: null, hitCount: 5}
     ];
     const requestedTokens = [];
 
@@ -147,6 +147,18 @@ test("pagination continues when a partial detail page has a continuation token",
 
     assert.deepEqual(requestedTokens, [null, "page-2"]);
     assert.deepEqual(result.map(item => item.Id), ["item-1", "item-2"]);
+});
+
+test("pagination limits by scanned search hits, not valid detail items", async () => {
+    let calls = 0;
+
+    const result = await _internals.collectPaginatedItems(5, 10, async () => {
+        calls += 1;
+        return {items: [], continuationToken: `page-${calls + 1}`, hitCount: 5};
+    });
+
+    assert.equal(calls, 2);
+    assert.deepEqual(result, []);
 });
 
 test("pagination stops on repeated continuation tokens", async () => {

--- a/test/marketplaceFilters.test.js
+++ b/test/marketplaceFilters.test.js
@@ -15,7 +15,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const {buildPlayerMarketplaceFilter} = require("../src/utils/marketplaceFilters");
-const {buildFilter: buildQueryFilter, filterItemsByDate} = require("../src/utils/filter");
+const {buildFilter: buildQueryFilter, buildContentTypeFilter, filterItemsByDate} = require("../src/utils/filter");
 const { _internals: advancedSearchInternals } = require("../src/services/advancedSearchService");
 const {loadCreators, resolveCreatorId} = require("../src/utils/creators");
 
@@ -50,6 +50,22 @@ test("buildFilter maps PlayFab date query filters", () => {
     assert.equal(result, "CreationDate ge 2025-12-01T00:00:00.000Z and LastModifiedDate le 2026-02-01T12:30:00.000Z and StartDate ge 2026-01-01T00:00:00.000Z");
 });
 
+test("buildFilter leaves contentType to search-specific filters", () => {
+    const result = buildQueryFilter({
+        query: {
+            contentType: "3PServerContent_V1.2",
+            creatorName: "100Media"
+        }
+    }, loadCreators());
+    const cid = resolveCreatorId(loadCreators(), "100Media");
+    assert.equal(result, `creatorId eq '${cid.replace(/'/g, "''")}'`);
+});
+
+test("buildContentTypeFilter supports multiple content types", () => {
+    const result = buildContentTypeFilter(["3PServerContent_V1.2", "shell_3PServerContent_V1.2"]);
+    assert.equal(result, "(ContentType eq '3PServerContent_V1.2' or ContentType eq 'shell_3PServerContent_V1.2')");
+});
+
 test("filterItemsByDate filters raw items and sales rawItem entries", () => {
     const items = [
         {Id: "one", StartDate: "2026-01-10T00:00:00Z"},
@@ -63,6 +79,13 @@ test("filterItemsByDate filters raw items and sales rawItem entries", () => {
 test("buildFilter maps contentKinds to tag filters", () => {
     const filter = advancedSearchInternals.buildFilter("alias", {filters: {contentKinds: ["skinpack", "world"]}});
     assert.equal(filter, "(tags/any(t:t eq 'skinpack') or tags/any(t:t eq 'worldtemplate'))");
+});
+
+test("advanced buildPlayFabFilter maps contentType filters", () => {
+    const filter = advancedSearchInternals.buildPlayFabFilter({
+        contentTypes: ["3PServerContent_V1.2", "shell_3PServerContent_V1.2"]
+    });
+    assert.equal(filter, "(ContentType eq '3PServerContent_V1.2' or ContentType eq 'shell_3PServerContent_V1.2')");
 });
 
 test("buildFilter maps persona contentKinds to exclude tags", () => {


### PR DESCRIPTION
- Fixes item watcher pagination so fallback scans continue and stop correctly.
- Adds content signature detection to reliably emit updates for content-only item changes.
- Adds tests for item watcher pagination, content signature changes, and featured content change payloads.
- Adds contentType filtering only to search endpoints:
    - GET /marketplace/search/:alias
    - POST /marketplace/search/advanced/:alias
    - POST /marketplace/player/search/:alias
- Updates validation, OpenAPI schemas, README, and Postman collection for the new search filters.
- Verified with npm test: 49 tests passed.