### PR TITLE
Add content update watcher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,6 +221,7 @@ Optional generator inputs are `CATALOG_BRIDGE_TOKEN_SUB`, `CATALOG_BRIDGE_TOKEN_
 | ------------------------- | ------- | ------------------------------------------- |
 | `ENABLE_SALES_WATCHER`    | `true`  | Enable sales watcher                        |
 | `ENABLE_ITEM_WATCHER`     | `true`  | Enable item watcher                         |
+| `ENABLE_CONTENT_UPDATE_WATCHER` | inherits item watcher | Enable playable content revision watcher |
 | `ENABLE_PRICE_WATCHER`    | `true`  | Enable price watcher                        |
 | `ENABLE_TRENDING_WATCHER` | `true`  | Enable trending watcher                     |
 | `ENABLE_CREATOR_PARTNER_WATCHER` | `true` | Enable creator/partner registry watcher |
@@ -230,6 +231,11 @@ Optional generator inputs are `CATALOG_BRIDGE_TOKEN_SUB`, `CATALOG_BRIDGE_TOKEN_
 | `SALES_WATCH_INTERVAL_MS` | `30000` | Sales watcher interval                      |
 | `PRICE_WATCH_INTERVAL_MS` | `30000` | Price watcher interval                      |
 | `ITEM_WATCH_INTERVAL_MS`  | `30000` | Item watcher interval                       |
+| `CONTENT_UPDATE_WATCH_INTERVAL_MS` | `30000` | Content revision watcher interval     |
+| `CONTENT_UPDATE_WATCH_ITEMS_PER_REQUEST` | `200` | Items requested per content watcher batch |
+| `CONTENT_UPDATE_WATCH_MAX_ITEMS` | `10000` | Maximum items scanned per content watcher run |
+| `CONTENT_UPDATE_WATCH_OVERLAP_MS` | `60000` | Content watcher overlap window for reliable polling |
+| `CONTENT_UPDATE_WATCH_STATE_FILE` | `src/data/contentUpdateWatcherState.json` | Optional persistent state file path |
 | `ITEM_WATCH_CREATED_LOOKBACK_MS` | `86400000` | StartDate/CreationDate window for newly visible catalog items |
 | `FEATURED_CONTENT_WATCH_INTERVAL_MS` | `21600000` | Featured content watcher interval |
 | `SUBSCRIPTION_WATCH_INTERVAL_MS` | `300000` | Marketplace Pass / Realms Plus watcher interval |
@@ -841,7 +847,7 @@ Not allowed (returns `400`):
 #### Events (SSE)
 
 * `/events/stream` (optional query `events=<comma-separated-event-names>`):
-  `item.snapshot`, `item.created`, `item.updated`, `marketplace.pass.snapshot`, `marketplace.pass.added`, `marketplace.pass.removed`, `marketplace.pass.updated`, `realms.plus.snapshot`, `realms.plus.added`, `realms.plus.removed`, `realms.plus.updated`, `sale.snapshot`, `sale.update`, `price.changed`, `creator.trending`, `featured.content.added`, `featured.content.removed`, `featured.content.updated`.
+  `item.snapshot`, `item.created`, `item.updated`, `item.content.updated`, `marketplace.pass.snapshot`, `marketplace.pass.added`, `marketplace.pass.removed`, `marketplace.pass.updated`, `realms.plus.snapshot`, `realms.plus.added`, `realms.plus.removed`, `realms.plus.updated`, `sale.snapshot`, `sale.update`, `price.changed`, `creator.trending`, `featured.content.added`, `featured.content.removed`, `featured.content.updated`.
 * Subscription events compare the current `csb` / `realms_plus` tag memberships with the last persisted watcher state. Added/removed events include the current item list, updated events include `before` / `after` entries, and each item includes `subscription.startDate` / `subscription.endDate` from `csbStartDate`, `csbEndDate`, `realmsPlusStartDate`, and `realmsPlusEndDate`.
 * Featured content changes emit dedicated `featured.content.added`, `featured.content.removed`, and `featured.content.updated` events. Payloads include the matching `addedItems`, `removedItems`, or `changedItems` plus item details with `featuredContext` (`page`, `row`, `component`, `itemIndex`); `currentItemDetails` and `previousItemDetails` provide the full after/before featured item lists. Same-ID layout or metadata changes emit `featured.content.updated`, set `contentChanged=true`, and include `previousContentSignature` / `currentContentSignature`.
 
@@ -966,7 +972,7 @@ Rate limiting is controlled via the `RATE_LIMIT_*` environment variables.
 * **Backpressure**: events are small JSON payloads; consumers should be idempotent.
 * Watchers are toggled with:
 
-  * `ENABLE_ITEM_WATCHER`, `ENABLE_PRICE_WATCHER`, `ENABLE_SALES_WATCHER`, `ENABLE_TRENDING_WATCHER`, `ENABLE_CREATOR_PARTNER_WATCHER`, `ENABLE_FEATURED_CONTENT_WATCHER`, `ENABLE_SUBSCRIPTION_WATCHER`.
+  * `ENABLE_ITEM_WATCHER`, `ENABLE_CONTENT_UPDATE_WATCHER`, `ENABLE_PRICE_WATCHER`, `ENABLE_SALES_WATCHER`, `ENABLE_TRENDING_WATCHER`, `ENABLE_CREATOR_PARTNER_WATCHER`, `ENABLE_FEATURED_CONTENT_WATCHER`, `ENABLE_SUBSCRIPTION_WATCHER`.
 
 ---
 
@@ -980,7 +986,7 @@ curl -sS -X POST http://localhost:3000/webhooks \
   -d '{"event":"price.changed","url":"https://example.com/hook","secret":"<optional-256-max>"}'
 ```
 
-**Events**: `sale.update`, `item.snapshot`, `item.created`, `item.updated`, `marketplace.pass.snapshot`, `marketplace.pass.added`, `marketplace.pass.removed`, `marketplace.pass.updated`, `realms.plus.snapshot`, `realms.plus.added`, `realms.plus.removed`, `realms.plus.updated`, `price.changed`, `creator.trending`, `featured.content.added`, `featured.content.removed`, `featured.content.updated`
+**Events**: `sale.update`, `item.snapshot`, `item.created`, `item.updated`, `item.content.updated`, `marketplace.pass.snapshot`, `marketplace.pass.added`, `marketplace.pass.removed`, `marketplace.pass.updated`, `realms.plus.snapshot`, `realms.plus.added`, `realms.plus.removed`, `realms.plus.updated`, `price.changed`, `creator.trending`, `featured.content.added`, `featured.content.removed`, `featured.content.updated`
 
 **Delivery**
 
@@ -1181,6 +1187,8 @@ ENABLE_SALES_WATCHER=true
 SALES_WATCH_INTERVAL_MS=30000
 ENABLE_ITEM_WATCHER=true
 ITEM_WATCH_INTERVAL_MS=30000
+ENABLE_CONTENT_UPDATE_WATCHER=true
+CONTENT_UPDATE_WATCH_INTERVAL_MS=30000
 ITEM_WATCH_TOP=150
 ITEM_WATCH_PAGES=3
 ENABLE_PRICE_WATCHER=true

--- a/src/config/eventNames.js
+++ b/src/config/eventNames.js
@@ -16,6 +16,7 @@ const EVENT_NAMES = Object.freeze([
     "item.snapshot",
     "item.created",
     "item.updated",
+    "item.content.updated",
     "marketplace.pass.snapshot",
     "marketplace.pass.added",
     "marketplace.pass.removed",

--- a/src/controllers/healthController.js
+++ b/src/controllers/healthController.js
@@ -18,6 +18,7 @@ const {sendPlayFabRequest, getStoreItems, getSession} = require("../utils/playfa
 const {resolveTitle} = require("../utils/titles");
 const {salesWatcher} = require("../services/salesWatcher");
 const {itemWatcher} = require("../services/itemWatcher");
+const {contentUpdateWatcher} = require("../services/contentUpdateWatcher");
 const {priceWatcher} = require("../services/priceWatcher");
 const {trendingWatcher} = require("../services/trendingWatcher");
 const {creatorPartnerWatcher} = require("../services/creatorPartnerWatcher");
@@ -329,6 +330,9 @@ function getConfigInfo() {
         }, watchersEnabled: {
             sales: readBoolEnv("ENABLE_SALES_WATCHER"),
             item: readBoolEnv("ENABLE_ITEM_WATCHER"),
+            contentUpdate: process.env.ENABLE_CONTENT_UPDATE_WATCHER == null
+                ? readBoolEnv("ENABLE_ITEM_WATCHER")
+                : readBoolEnv("ENABLE_CONTENT_UPDATE_WATCHER"),
             price: readBoolEnv("ENABLE_PRICE_WATCHER"),
             trending: readBoolEnv("ENABLE_TRENDING_WATCHER"),
             creatorPartner: readBoolEnv("ENABLE_CREATOR_PARTNER_WATCHER"),
@@ -336,6 +340,7 @@ function getConfigInfo() {
         }, watcherIntervals: {
             salesMs: readIntEnv("SALES_WATCH_INTERVAL_MS", 30000),
             itemMs: readIntEnv("ITEM_WATCH_INTERVAL_MS", 30000),
+            contentUpdateMs: readIntEnv("CONTENT_UPDATE_WATCH_INTERVAL_MS", 30000),
             priceMs: readIntEnv("PRICE_WATCH_INTERVAL_MS", 30000),
             trendingMs: readIntEnv("TRENDING_INTERVAL_MS", 60000),
             creatorPartnerMs: readIntEnv("CREATOR_PARTNER_WATCH_INTERVAL_MS", 21600000),
@@ -430,6 +435,7 @@ exports.getHealth = async (_req, res, next) => {
         const watchers = {
             salesWatcher: watcherDetails(salesWatcher, "SALES", configInfo.watchersEnabled.sales),
             itemWatcher: watcherDetails(itemWatcher, "ITEM", configInfo.watchersEnabled.item),
+            contentUpdateWatcher: watcherDetails(contentUpdateWatcher, "CONTENT_UPDATE", configInfo.watchersEnabled.contentUpdate),
             priceWatcher: watcherDetails(priceWatcher, "PRICE", configInfo.watchersEnabled.price),
             trendingWatcher: watcherDetails(trendingWatcher, "TRENDING", configInfo.watchersEnabled.trending),
             creatorPartnerWatcher: watcherDetails(creatorPartnerWatcher, "CREATOR_PARTNER", configInfo.watchersEnabled.creatorPartner)

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ const OpenApiValidator = require("express-openapi-validator");
 const NodeCache = require("node-cache");
 const {salesWatcher} = require("./services/salesWatcher");
 const {itemWatcher} = require("./services/itemWatcher");
+const {contentUpdateWatcher} = require("./services/contentUpdateWatcher");
 const {subscriptionWatcher} = require("./services/subscriptionWatcher");
 const {priceWatcher} = require("./services/priceWatcher");
 const {trendingWatcher} = require("./services/trendingWatcher");
@@ -477,6 +478,13 @@ app.listen(port, async () => {
     if (process.env.ENABLE_ITEM_WATCHER === "true") {
         itemWatcher.start(eventBus);
         logger.info("Item watcher started");
+    }
+    const contentUpdateWatcherEnabled = process.env.ENABLE_CONTENT_UPDATE_WATCHER == null
+        ? process.env.ENABLE_ITEM_WATCHER === "true"
+        : process.env.ENABLE_CONTENT_UPDATE_WATCHER === "true";
+    if (contentUpdateWatcherEnabled) {
+        contentUpdateWatcher.start(eventBus);
+        logger.info("Content update watcher started");
     }
     if (process.env.ENABLE_SUBSCRIPTION_WATCHER === "true") {
         subscriptionWatcher.start(eventBus);

--- a/src/services/contentUpdateWatcher.js
+++ b/src/services/contentUpdateWatcher.js
@@ -1,0 +1,252 @@
+// -----------------------------------------------------------------------------
+//
+// File: src/services/contentUpdateWatcher.js
+// Disclaimer: "PlayFab Catalog Service Bedrock" by SpindexGFX is an independent project.
+// It is not affiliated with, endorsed by, sponsored by, or otherwise connected to Mojang AB,
+// Microsoft Corporation, or any of their subsidiaries or affiliates.
+// No partnership, approval, or official relationship with Mojang AB or Microsoft is implied.
+//
+// All names, logos, brands, trademarks, service marks, and registered trademarks are the
+// property of their respective owners and are used strictly for identification/reference only.
+// This project does not claim ownership of third-party IP and provides no license to use it.
+//
+// -----------------------------------------------------------------------------
+
+const fs = require("fs");
+const path = require("path");
+const logger = require("../config/logger");
+const {stableHash} = require("../utils/hash");
+const {createNonOverlappingRunner} = require("../utils/watcherRun");
+const {projectCatalogItem} = require("../utils/projectors");
+const {readJson, writeJsonAtomic} = require("../utils/storage");
+const {_internals: itemWatcherInternals} = require("./itemWatcher");
+
+const DEFAULT_STATE_FILE = path.join(__dirname, "../data/contentUpdateWatcherState.json");
+
+function compactText(value) {
+    if (value == null) return "";
+    return String(value).trim();
+}
+
+function normalizeVersion(value) {
+    if (Array.isArray(value)) return value.map(compactText).filter(Boolean).join(".");
+    return compactText(value);
+}
+
+function normalizePackIdentities(item) {
+    const identities = item?.DisplayProperties?.packIdentity;
+    if (!Array.isArray(identities)) return [];
+    return identities.map(entry => ({
+        type: compactText(entry?.type).toLowerCase(),
+        uuid: compactText(entry?.uuid || entry?.id).toLowerCase(),
+        version: normalizeVersion(entry?.version)
+    })).filter(entry => entry.type || entry.uuid || entry.version).sort((a, b) => `${a.type}|${a.uuid}`.localeCompare(`${b.type}|${b.uuid}`));
+}
+
+function normalizeContentVariants(item) {
+    const contents = Array.isArray(item?.Contents) ? item.Contents : [];
+    return contents.map(entry => ({
+        id: compactText(entry?.Id || entry?.id).toLowerCase(),
+        url: compactText(entry?.Url || entry?.url),
+        type: compactText(entry?.Type || entry?.type).toLowerCase(),
+        minClientVersion: normalizeVersion(entry?.MinClientVersion || entry?.minClientVersion),
+        maxClientVersion: normalizeVersion(entry?.MaxClientVersion || entry?.maxClientVersion),
+        tags: (Array.isArray(entry?.Tags) ? entry.Tags : []).map(compactText).filter(Boolean).sort((a, b) => a.localeCompare(b))
+    })).filter(entry => entry.id || entry.type || entry.minClientVersion || entry.maxClientVersion || entry.tags.length)
+        .sort((a, b) => `${a.id}|${a.type}`.localeCompare(`${b.id}|${b.type}`));
+}
+
+function contentRevisionOf(item) {
+    const display = item?.DisplayProperties || {};
+    return {
+        packs: normalizePackIdentities(item),
+        variants: normalizeContentVariants(item),
+        gameVersion: normalizeVersion(display.lastUpdated),
+        minClientVersion: normalizeVersion(display.minClientVersion),
+        maxClientVersion: normalizeVersion(display.maxClientVersion),
+        totalContentFileSize: Number.isFinite(Number(display.totalContentFileSize)) ? Number(display.totalContentFileSize) : null
+    };
+}
+
+function contentRevisionHash(item) {
+    return stableHash(contentRevisionOf(item));
+}
+
+function indexBy(values, keyOf) {
+    return new Map((values || []).map(value => [keyOf(value), value]));
+}
+
+function diffRevision(beforeItem, afterItem) {
+    const before = contentRevisionOf(beforeItem);
+    const after = contentRevisionOf(afterItem);
+    const changes = [];
+    const compareList = (kind, previous, current, keyOf) => {
+        const previousByKey = indexBy(previous, keyOf);
+        const currentByKey = indexBy(current, keyOf);
+        const keys = new Set([...previousByKey.keys(), ...currentByKey.keys()]);
+        for (const key of keys) {
+            const oldValue = previousByKey.get(key) || null;
+            const newValue = currentByKey.get(key) || null;
+            if (stableHash(oldValue) === stableHash(newValue)) continue;
+            changes.push({kind, key, before: oldValue, after: newValue});
+        }
+    };
+
+    compareList("pack", before.packs, after.packs, value => value.uuid || value.type);
+    compareList("content", before.variants, after.variants, value => value.id || `${value.type}|${value.minClientVersion}`);
+    for (const field of ["gameVersion", "minClientVersion", "maxClientVersion", "totalContentFileSize"]) {
+        if (before[field] !== after[field]) changes.push({kind: "property", key: field, before: before[field], after: after[field]});
+    }
+    return changes;
+}
+
+function stateFilePath() {
+    return process.env.CONTENT_UPDATE_WATCH_STATE_FILE || DEFAULT_STATE_FILE;
+}
+
+function serializeState(state) {
+    return Array.from(state.entries()).map(([id, entry]) => ({id, hash: entry.hash, raw: entry.raw || null})).filter(entry => entry.id && entry.hash);
+}
+
+function deserializeState(entries) {
+    const state = new Map();
+    if (!Array.isArray(entries)) return state;
+    for (const entry of entries) {
+        const id = entry?.id || entry?.raw?.Id || entry?.raw?.id;
+        if (!id || !entry?.hash) continue;
+        state.set(id, {hash: entry.hash, raw: entry.raw || null});
+    }
+    return state;
+}
+
+function loadPersistedState() {
+    try {
+        const filePath = stateFilePath();
+        if (!fs.existsSync(filePath)) return {state: new Map(), loaded: false};
+        return {state: deserializeState(readJson(filePath, [])), loaded: true};
+    } catch (err) {
+        logger.warn(`[ContentUpdateWatcher] failed to load state file: ${err.message}`);
+        return {state: new Map(), loaded: false};
+    }
+}
+
+function savePersistedState(state) {
+    try {
+        writeJsonAtomic(stateFilePath(), serializeState(state));
+    } catch (err) {
+        logger.warn(`[ContentUpdateWatcher] failed to save state file: ${err.message}`);
+    }
+}
+
+function buildContentUpdate(previous, current) {
+    if (!previous?.raw || !current) return null;
+    const hash = contentRevisionHash(current);
+    if (previous.hash === hash) return null;
+    const changes = diffRevision(previous.raw, current);
+    if (!changes.length) return null;
+    return {id: current.Id || current.id, before: previous.raw, after: current, changes, hash};
+}
+
+class ContentUpdateWatcher {
+    constructor() {
+        this.running = false;
+        this.timer = null;
+        this.state = new Map();
+        this.lastRunTs = 0;
+        this.bootstrapped = false;
+    }
+
+    start(eventBus) {
+        if (this.running) return;
+        this.running = true;
+        const os = process.env.OS || "iOS";
+        const intervalMs = Math.max(10000, parseInt(process.env.CONTENT_UPDATE_WATCH_INTERVAL_MS || "30000", 10));
+        const itemsPerRequest = Math.max(10, parseInt(process.env.CONTENT_UPDATE_WATCH_ITEMS_PER_REQUEST || "200", 10));
+        const maxItems = Math.max(itemsPerRequest, parseInt(process.env.CONTENT_UPDATE_WATCH_MAX_ITEMS || "10000", 10));
+        const overlapMs = Math.max(0, parseInt(process.env.CONTENT_UPDATE_WATCH_OVERLAP_MS || "60000", 10));
+
+        const run = async () => {
+            const titleId = itemWatcherInternals.getTitleId();
+            if (!this.bootstrapped) {
+                const recent = await itemWatcherInternals.fetchBootstrapItems(titleId, os, itemsPerRequest, maxItems, 0);
+                const persisted = loadPersistedState();
+                const nextState = new Map(persisted.state);
+                const updates = [];
+                for (const item of recent) {
+                    const id = item.Id || item.id;
+                    if (!id) continue;
+                    const previous = persisted.state.get(id) || null;
+                    const update = persisted.loaded ? buildContentUpdate(previous, item) : null;
+                    if (update) updates.push(update);
+                    nextState.set(id, {hash: contentRevisionHash(item), raw: item});
+                }
+                this.state = nextState;
+                this.lastRunTs = Date.now();
+                this.bootstrapped = true;
+                this.emitUpdates(eventBus, updates);
+                savePersistedState(this.state);
+                return;
+            }
+
+            const sinceTs = Math.max(0, (this.lastRunTs || Date.now()) - overlapMs);
+            const sinceIso = new Date(sinceTs).toISOString();
+            const changed = await itemWatcherInternals.requestChangedItems(titleId, os, sinceIso, itemsPerRequest, maxItems, sinceIso);
+            const updates = [];
+            for (const item of changed) {
+                const id = item.Id || item.id;
+                if (!id) continue;
+                const previous = this.state.get(id) || null;
+                const update = buildContentUpdate(previous, item);
+                if (update) updates.push(update);
+                this.state.set(id, {hash: contentRevisionHash(item), raw: item});
+            }
+            this.emitUpdates(eventBus, updates);
+            savePersistedState(this.state);
+            this.lastRunTs = Date.now();
+        };
+
+        const runOnce = createNonOverlappingRunner({
+            run,
+            onError: err => logger.error(`[ContentUpdateWatcher] run failed: ${err.stack || err.message}`),
+            onSkip: () => logger.debug("[ContentUpdateWatcher] previous run still in progress; skipping tick")
+        });
+        runOnce();
+        this.timer = setInterval(runOnce, intervalMs);
+    }
+
+    emitUpdates(eventBus, updates) {
+        if (!updates.length) return;
+        eventBus.emit("item.content.updated", {
+            ts: Date.now(),
+            count: updates.length,
+            items: updates.map(update => ({
+                id: update.id,
+                before: projectCatalogItem(update.before),
+                after: projectCatalogItem(update.after),
+                changes: update.changes
+            }))
+        });
+    }
+
+    stop() {
+        if (!this.running) return;
+        this.running = false;
+        if (this.timer) clearInterval(this.timer);
+        this.timer = null;
+    }
+}
+
+const contentUpdateWatcher = new ContentUpdateWatcher();
+module.exports = {
+    contentUpdateWatcher,
+    _internals: {
+        normalizePackIdentities,
+        normalizeContentVariants,
+        contentRevisionOf,
+        contentRevisionHash,
+        diffRevision,
+        buildContentUpdate,
+        serializeState,
+        deserializeState
+    }
+};

--- a/src/services/itemWatcher.js
+++ b/src/services/itemWatcher.js
@@ -61,6 +61,16 @@ function toFilterDateLiteral(iso) {
 }
 
 function hashItemCore(it) {
+    const displayProperties = it.DisplayProperties && typeof it.DisplayProperties === "object"
+        ? {...it.DisplayProperties}
+        : it.DisplayProperties;
+    if (displayProperties && typeof displayProperties === "object") {
+        delete displayProperties.packIdentity;
+        delete displayProperties.lastUpdated;
+        delete displayProperties.minClientVersion;
+        delete displayProperties.maxClientVersion;
+        delete displayProperties.totalContentFileSize;
+    }
     const core = {
         Id: it.Id || it.id,
         Title: it.Title,
@@ -69,7 +79,7 @@ function hashItemCore(it) {
         ContentType: it.ContentType || it.contentType,
         Platforms: it.Platforms,
         Images: Array.isArray(it.Images) ? it.Images.map(i => [i.Tag || i.tag, i.Url || i.url]) : [],
-        DisplayProperties: it.DisplayProperties,
+        DisplayProperties: displayProperties,
         ETag: it.ETag,
         LastModifiedDate: lastModifiedDateOf(it),
         StartDate: startDateOf(it),
@@ -281,7 +291,7 @@ function deserializeState(entries) {
         const hash = entry?.hash;
         if (!id || !hash) continue;
         state.set(id, {
-            hash,
+            hash: entry.raw ? hashItemCore(entry.raw) : hash,
             raw: entry.raw || null,
             createdNotified: entry.createdNotified === false ? false : true
         });
@@ -553,6 +563,11 @@ module.exports = {
         buildChangedItemRequests,
         classifyBootstrapItemChange,
         serializeState,
-        deserializeState
+        deserializeState,
+        fetchBootstrapItems,
+        requestChangedItems,
+        lastModifiedDateOf,
+        tsOf,
+        getTitleId
     }
 };

--- a/src/utils/eventPayload.js
+++ b/src/utils/eventPayload.js
@@ -27,6 +27,7 @@ function creatorNameOf(item) {
 
 function isUpdatedItemListEvent(eventName) {
     return eventName === "item.updated"
+        || eventName === "item.content.updated"
         || eventName === "marketplace.pass.updated"
         || eventName === "realms.plus.updated";
 }

--- a/test/contentUpdateWatcher.test.js
+++ b/test/contentUpdateWatcher.test.js
@@ -1,0 +1,68 @@
+// -----------------------------------------------------------------------------
+//
+// File: test/contentUpdateWatcher.test.js
+// Disclaimer: "PlayFab Catalog Service Bedrock" by SpindexGFX is an independent project.
+// It is not affiliated with, endorsed by, sponsored by, or otherwise connected to Mojang AB,
+// Microsoft Corporation, or any of their subsidiaries or affiliates.
+//
+// -----------------------------------------------------------------------------
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {_internals} = require("../src/services/contentUpdateWatcher");
+
+function makeItem(overrides = {}) {
+    return {
+        Id: "content-item",
+        Title: {NEUTRAL: "Content Item"},
+        Rating: {Average: 4, TotalCount: 10},
+        DisplayProperties: {
+            creatorName: "Creator",
+            lastUpdated: "1.21.0",
+            packIdentity: [{type: "behaviorpack", uuid: "pack-a", version: "1.0.0"}],
+            totalContentFileSize: 1000
+        },
+        Contents: [{Id: "content-a", Type: "resourcebinary", MinClientVersion: "1.16.0", MaxClientVersion: "65535.65535.65535", Tags: []}],
+        ...overrides
+    };
+}
+
+test("content revision ignores rating and catalog metadata changes", () => {
+    const before = makeItem();
+    const after = {...before, Rating: {Average: 4.5, TotalCount: 50}, ETag: "new-etag"};
+    assert.equal(_internals.contentRevisionHash(before), _internals.contentRevisionHash(after));
+    assert.deepEqual(_internals.diffRevision(before, after), []);
+});
+
+test("content revision detects pack versions and optimized content variants", () => {
+    const before = makeItem();
+    const after = makeItem({
+        DisplayProperties: {...before.DisplayProperties, lastUpdated: "1.26.40", packIdentity: [{type: "behaviorpack", uuid: "pack-a", version: "1.0.6"}]},
+        Contents: [...before.Contents, {Id: "content-b", Type: "resourcebinary", MinClientVersion: "1.26.40", MaxClientVersion: "65535.65535.65535", Tags: ["optimized-1.26.40"]}]
+    });
+    const changes = _internals.diffRevision(before, after);
+    assert.ok(changes.some(change => change.kind === "pack" && change.before.version === "1.0.0" && change.after.version === "1.0.6"));
+    assert.ok(changes.some(change => change.kind === "content" && change.after.id === "content-b"));
+    assert.ok(changes.some(change => change.kind === "property" && change.key === "gameVersion" && change.after === "1.26.40"));
+});
+
+test("buildContentUpdate requires a previous snapshot and a real content change", () => {
+    const before = makeItem();
+    const previous = {hash: _internals.contentRevisionHash(before), raw: before};
+    assert.equal(_internals.buildContentUpdate(previous, {...before, ETag: "changed"}), null);
+    assert.equal(_internals.buildContentUpdate(null, before), null);
+    const after = makeItem({DisplayProperties: {...before.DisplayProperties, totalContentFileSize: 2000}});
+    const update = _internals.buildContentUpdate(previous, after);
+    assert.equal(update.id, "content-item");
+    assert.ok(update.changes.some(change => change.key === "totalContentFileSize"));
+});
+
+test("content revision detects a replaced binary with unchanged compatibility", () => {
+    const before = makeItem({Contents: [{Id: "content-a", Url: "https://cdn.example/old.zip", Type: "resourcebinary", MinClientVersion: "1.16.0", MaxClientVersion: "65535.65535.65535", Tags: []}]});
+    const after = makeItem({Contents: [{Id: "content-a", Url: "https://cdn.example/new.zip", Type: "resourcebinary", MinClientVersion: "1.16.0", MaxClientVersion: "65535.65535.65535", Tags: []}]});
+    const changes = _internals.diffRevision(before, after);
+    assert.equal(changes.length, 1);
+    assert.equal(changes[0].kind, "content");
+    assert.equal(changes[0].before.url, "https://cdn.example/old.zip");
+    assert.equal(changes[0].after.url, "https://cdn.example/new.zip");
+});

--- a/test/itemWatcher.test.js
+++ b/test/itemWatcher.test.js
@@ -83,6 +83,23 @@ test("classifyItemChange keeps changed known items as updated", () => {
     assert.equal(result.kind, "updated");
 });
 
+test("classifyItemChange leaves content revisions to the content update watcher", () => {
+    const previousItem = makeItem({DisplayProperties: {
+        creatorName: "Creator",
+        lastUpdated: "1.21.0",
+        packIdentity: [{type: "behaviorpack", uuid: "pack-a", version: "1.0.0"}],
+        totalContentFileSize: 1000
+    }});
+    const currentItem = makeItem({DisplayProperties: {
+        creatorName: "Creator",
+        lastUpdated: "1.26.40",
+        packIdentity: [{type: "behaviorpack", uuid: "pack-a", version: "1.0.6"}],
+        totalContentFileSize: 2000
+    }});
+    const result = _internals.classifyItemChange(currentItem, previousStateFor(previousItem), SINCE_TS);
+    assert.equal(result.kind, null);
+});
+
 test("classifyItemChange prefers created for known items whose created event was suppressed", () => {
     const previousItem = makeItem({Title: {NEUTRAL: "Draft"}, ETag: "etag-draft"});
     const currentItem = makeItem({Title: {NEUTRAL: "Published"}, ETag: "etag-published"});


### PR DESCRIPTION
- Adds a dedicated watcher for playable content revision changes.
- Emits item.content.updated events with before, after, and changed content fields.
- Keeps catalog metadata changes in the existing item watcher and content revisions in the new watcher.
- Adds health status, startup configuration, persisted state, tests, and README documentation.